### PR TITLE
fix：[Site]: language quick start Button lost language path

### DIFF
--- a/src/components/HomePageLanguageCard/index.tsx
+++ b/src/components/HomePageLanguageCard/index.tsx
@@ -1,83 +1,88 @@
 import React from "react";
 import { Card } from "antd";
 
-export const HomePageLanguageCard = () => (
-  <div>
-    <div style={{ textAlign: "center" }}>
-      <h2>Quick Start!</h2>
-      <p>Choose a language to get started .</p>
+export const HomePageLanguageCard = () => {
+  const locale = "zh-CN"; 
+
+  const getLanguageUrl = (language) => {
+    const baseUrl = locale === "zh-CN" 
+      ? "https://fury.apache.org/zh-CN/docs/start/usage/#" 
+      : "https://fury.apache.org/docs/start/usage/#";
+    return `${baseUrl}${language}`;
+  };
+
+  return (
+    <div>
+      <div style={{ textAlign: "center" }}>
+        <h2>Quick Start!</h2>
+        <p>Choose a language to get started.</p>
+      </div>
+      <Card
+        style={{
+          width: "60%",
+          margin: "0 auto",
+          borderRadius: "10px",
+          boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
+        }}
+      >
+        <Card.Grid
+          style={gridStyle}
+          onClick={() => {
+            window.location.href = getLanguageUrl("java-serialization");
+          }}
+        >
+          <img src="../java.svg" style={imageStyle} alt="Java logo" />
+          Java
+        </Card.Grid>
+        <Card.Grid
+          style={gridStyle}
+          onClick={() => {
+            window.location.href = getLanguageUrl("python");
+          }}
+        >
+          <img src="../python.svg" style={imageStyle} alt="Python logo" />
+          Python
+        </Card.Grid>
+        <Card.Grid
+          style={gridStyle}
+          onClick={() => {
+            window.location.href = getLanguageUrl("golang");
+          }}
+        >
+          <img src="../golang.svg" style={imageStyle} alt="Golang logo" />
+          Golang
+        </Card.Grid>
+        <Card.Grid
+          style={gridStyle}
+          onClick={() => {
+            window.location.href = getLanguageUrl("javascript");
+          }}
+        >
+          <img src="../JavaScript.svg" style={imageStyle} alt="JavaScript logo" />
+          JavaScript
+        </Card.Grid>
+        <Card.Grid
+          style={gridStyle}
+          onClick={() => {
+            window.location.href = getLanguageUrl("rust");
+          }}
+        >
+          <img src="../Rust.svg" style={imageStyle} alt="Rust logo" />
+          Rust
+        </Card.Grid>
+        <Card.Grid
+          style={gridStyle}
+          onClick={() => {
+            window.location.href = getLanguageUrl("crosslanguage-serialization");
+          }}
+        >
+          <img src="../more.svg" style={imageStyle} alt="More languages" />
+          More
+        </Card.Grid>
+      </Card>
     </div>
-    <Card
-      style={{
-        width: "60%",
-        margin: "0 auto",
-        borderRadius: "10px",
-        boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
-      }}
-    >
-      <Card.Grid
-        style={gridStyle}
-        onClick={() => {
-          window.location.href =
-            "https://fury.apache.org/docs/start/usage/#java-serialization";
-        }}
-      >
-        <img src="..//java.svg" style={imageStyle} />
-        Java
-      </Card.Grid>
-      <Card.Grid
-        style={gridStyle}
-        onClick={() => {
-          window.location.href =
-            "https://fury.apache.org/docs/start/usage/#python";
-        }}
-      >
-        <img src="..//python.svg" style={imageStyle} />
-        Python
-      </Card.Grid>
-      <Card.Grid
-        style={gridStyle}
-        onClick={() => {
-          window.location.href =
-            "https://fury.apache.org/docs/start/usage/#golang";
-        }}
-      >
-        <img src="..//golang.svg" style={imageStyle} />
-        Golang
-      </Card.Grid>
-      <Card.Grid
-        style={gridStyle}
-        onClick={() => {
-          window.location.href =
-            "https://fury.apache.org/docs/start/usage/#javascript";
-        }}
-      >
-        <img src="..//JavaScript.svg" style={imageStyle} />
-        JavaScript
-      </Card.Grid>
-      <Card.Grid
-        style={gridStyle}
-        onClick={() => {
-          window.location.href =
-            "https://fury.apache.org/docs/start/usage/#rust";
-        }}
-      >
-        <img src="..//Rust.svg" style={imageStyle} />
-        Rust
-      </Card.Grid>
-      <Card.Grid
-        style={gridStyle}
-        onClick={() => {
-          window.location.href =
-            "https://fury.apache.org/docs/start/usage/#crosslanguage-serialization";
-        }}
-      >
-        <img src="..//more.svg" style={imageStyle} />
-        More
-      </Card.Grid>
-    </Card>
-  </div>
-);
+  );
+};
 
 const gridStyle: React.CSSProperties = {
   width: "50%",


### PR DESCRIPTION
Key Changes:
Locale Handling: Added a locale constant (which should come from your global state, user preferences, or URL path). getLanguageUrl Function: This function returns the correct URL based on the locale. If the locale is zh-CN, it adds /zh-CN/ to the path. Updated Click Handlers: The click handlers now use the getLanguageUrl function to navigate to the correct localized URL.

link to： https://github.com/apache/fury-site/issues/182