### PR TITLE
Fix：SSR issue by wrapping client-side code with <BrowserOnly> in HomePageLanguageCard

### DIFF
--- a/src/pages/home/components/HomePageLanguageCard.tsx
+++ b/src/pages/home/components/HomePageLanguageCard.tsx
@@ -1,102 +1,121 @@
 import React from "react";
 import { Card } from "antd";
 import useBaseUrl from "@docusaurus/useBaseUrl";
+import BrowserOnly from "@docusaurus/BrowserOnly";
 
 export default function HomePageLanguageCard() {
-  const locale = navigator.language || "en-US";
-
-  const getLanguageUrl = (language: string) => {
-    const baseUrl = locale.startsWith("zh-CN")
-      ? "https://fury.apache.org/zh-CN/docs/start/usage/#"
-      : "https://fury.apache.org/docs/start/usage/#";
-    return `${baseUrl}${language}`;
-  };
-
-  const imageUrls = {
-    java: useBaseUrl("/home/java.svg"),
-    python: useBaseUrl("/home/python.svg"),
-    golang: useBaseUrl("/home/golang.svg"),
-    javascript: useBaseUrl("/home/JavaScript.svg"),
-    rust: useBaseUrl("/home/Rust.svg"),
-    more: useBaseUrl("/home/more.svg"),
-  };
-
   return (
-    <div>
-      <div style={{ textAlign: "center" }}>
-        <h2>Quick Start!</h2>
-        <p>Choose a language to get started.</p>
-      </div>
-      <Card
-        style={{
-          width: "60%",
-          margin: "0 auto",
-          borderRadius: "10px",
-          boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
-        }}
-      >
-        <Card.Grid
-          style={gridStyle}
-          onClick={() => {
-            window.location.href = getLanguageUrl("java-serialization");
-          }}
-        >
-          <img src={imageUrls.java} style={imageStyle} alt="Java logo" />
-          Java
-        </Card.Grid>
-        <Card.Grid
-          style={gridStyle}
-          onClick={() => {
-            window.location.href = getLanguageUrl("python");
-          }}
-        >
-          <img src={imageUrls.python} style={imageStyle} alt="Python logo" />
-          Python
-        </Card.Grid>
-        <Card.Grid
-          style={gridStyle}
-          onClick={() => {
-            window.location.href = getLanguageUrl("golang");
-          }}
-        >
-          <img src={imageUrls.golang} style={imageStyle} alt="Golang logo" />
-          Golang
-        </Card.Grid>
-        <Card.Grid
-          style={gridStyle}
-          onClick={() => {
-            window.location.href = getLanguageUrl("javascript");
-          }}
-        >
-          <img
-            src={imageUrls.javascript}
-            style={imageStyle}
-            alt="JavaScript logo"
-          />
-          JavaScript
-        </Card.Grid>
-        <Card.Grid
-          style={gridStyle}
-          onClick={() => {
-            window.location.href = getLanguageUrl("rust");
-          }}
-        >
-          <img src={imageUrls.rust} style={imageStyle} alt="Rust logo" />
-          Rust
-        </Card.Grid>
-        <Card.Grid
-          style={gridStyle}
-          onClick={() => {
-            window.location.href = getLanguageUrl(
-              "crosslanguage-serialization"
-            );
-          }}
-        >
-          <img src={imageUrls.more} style={imageStyle} alt="More languages" />
-          More
-        </Card.Grid>
-      </Card>
-    </div>
+    <BrowserOnly>
+      {() => {
+        const locale = navigator.language || "en-US";
+
+        const getLanguageUrl = (language: string) => {
+          const baseUrl = locale.startsWith("zh-CN")
+            ? "https://fury.apache.org/zh-CN/docs/start/usage/#"
+            : "https://fury.apache.org/docs/start/usage/#";
+          return `${baseUrl}${language}`;
+        };
+
+        const imageUrls = {
+          java: useBaseUrl("/home/java.svg"),
+          python: useBaseUrl("/home/python.svg"),
+          golang: useBaseUrl("/home/golang.svg"),
+          javascript: useBaseUrl("/home/JavaScript.svg"),
+          rust: useBaseUrl("/home/Rust.svg"),
+          more: useBaseUrl("/home/more.svg"),
+        };
+
+        return (
+          <div>
+            <div style={{ textAlign: "center" }}>
+              <h2>Quick Start!</h2>
+              <p>Choose a language to get started.</p>
+            </div>
+            <Card
+              style={{
+                width: "60%",
+                margin: "0 auto",
+                borderRadius: "10px",
+                boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
+              }}
+            >
+              <Card.Grid
+                style={gridStyle}
+                onClick={() => {
+                  window.location.href = getLanguageUrl("java-serialization");
+                }}
+              >
+                <img src={imageUrls.java} style={imageStyle} alt="Java logo" />
+                Java
+              </Card.Grid>
+              <Card.Grid
+                style={gridStyle}
+                onClick={() => {
+                  window.location.href = getLanguageUrl("python");
+                }}
+              >
+                <img
+                  src={imageUrls.python}
+                  style={imageStyle}
+                  alt="Python logo"
+                />
+                Python
+              </Card.Grid>
+              <Card.Grid
+                style={gridStyle}
+                onClick={() => {
+                  window.location.href = getLanguageUrl("golang");
+                }}
+              >
+                <img
+                  src={imageUrls.golang}
+                  style={imageStyle}
+                  alt="Golang logo"
+                />
+                Golang
+              </Card.Grid>
+              <Card.Grid
+                style={gridStyle}
+                onClick={() => {
+                  window.location.href = getLanguageUrl("javascript");
+                }}
+              >
+                <img
+                  src={imageUrls.javascript}
+                  style={imageStyle}
+                  alt="JavaScript logo"
+                />
+                JavaScript
+              </Card.Grid>
+              <Card.Grid
+                style={gridStyle}
+                onClick={() => {
+                  window.location.href = getLanguageUrl("rust");
+                }}
+              >
+                <img src={imageUrls.rust} style={imageStyle} alt="Rust logo" />
+                Rust
+              </Card.Grid>
+              <Card.Grid
+                style={gridStyle}
+                onClick={() => {
+                  window.location.href = getLanguageUrl(
+                    "crosslanguage-serialization"
+                  );
+                }}
+              >
+                <img
+                  src={imageUrls.more}
+                  style={imageStyle}
+                  alt="More languages"
+                />
+                More
+              </Card.Grid>
+            </Card>
+          </div>
+        );
+      }}
+    </BrowserOnly>
   );
 }
 


### PR DESCRIPTION
In server-side rendering (SSR), navigatior objects are not available, navigatior is an object in a browser environment, so it will cause automated builds to fail, while in server-side rendering, the code is run in a nodeJS environment and there is no browser global object. I used the components provided by Docusaurus <BrowserOnly>to ensure that some code was only executed when rendered on the client side.
```js
 <BrowserOnly>
      {() => {
        const locale = navigator.language || "en-US";

        const getLanguageUrl = (language: string) => {
          const baseUrl = locale.startsWith("zh-CN")
            ? "https://fury.apache.org/zh-CN/docs/start/usage/#"
            : "https://fury.apache.org/docs/start/usage/#";
          return `${baseUrl}${language}`;
        };

        const imageUrls = {
          java: useBaseUrl("/home/java.svg"),
          python: useBaseUrl("/home/python.svg"),
          golang: useBaseUrl("/home/golang.svg"),
          javascript: useBaseUrl("/home/JavaScript.svg"),
          rust: useBaseUrl("/home/Rust.svg"),
          more: useBaseUrl("/home/more.svg"),
        };

        return (
          <div>
            <div style={{ textAlign: "center" }}>
              <h2>Quick Start!</h2>
              <p>Choose a language to get started.</p>
            </div>
            <Card
              style={{
                width: "60%",
                margin: "0 auto",
                borderRadius: "10px",
                boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
              }}
            >
              <Card.Grid
                style={gridStyle}
                onClick={() => {
                  window.location.href = getLanguageUrl("java-serialization");
                }}
              >
                <img src={imageUrls.java} style={imageStyle} alt="Java logo" />
                Java
              </Card.Grid>
              <Card.Grid
                style={gridStyle}
                onClick={() => {
                  window.location.href = getLanguageUrl("python");
                }}
              >
                <img
                  src={imageUrls.python}
                  style={imageStyle}
                  alt="Python logo"
                />
                Python
              </Card.Grid>
              <Card.Grid
                style={gridStyle}
                onClick={() => {
                  window.location.href = getLanguageUrl("golang");
                }}
              >
                <img
                  src={imageUrls.golang}
                  style={imageStyle}
                  alt="Golang logo"
                />
                Golang
              </Card.Grid>
              <Card.Grid
                style={gridStyle}
                onClick={() => {
                  window.location.href = getLanguageUrl("javascript");
                }}
              >
                <img
                  src={imageUrls.javascript}
                  style={imageStyle}
                  alt="JavaScript logo"
                />
                JavaScript
              </Card.Grid>
              <Card.Grid
                style={gridStyle}
                onClick={() => {
                  window.location.href = getLanguageUrl("rust");
                }}
              >
                <img src={imageUrls.rust} style={imageStyle} alt="Rust logo" />
                Rust
              </Card.Grid>
              <Card.Grid
                style={gridStyle}
                onClick={() => {
                  window.location.href = getLanguageUrl(
                    "crosslanguage-serialization"
                  );
                }}
              >
                <img
                  src={imageUrls.more}
                  style={imageStyle}
                  alt="More languages"
                />
                More
              </Card.Grid>
            </Card>
          </div>
        );
      }}
    </BrowserOnly>
```