### PR TITLE
fix: replace the removed withSecureMode API by requireClassRegistration

### DIFF
--- a/docs/start/usage.md
+++ b/docs/start/usage.md
@@ -19,7 +19,7 @@ public class Example {
     Fury fury = Fury.builder().withLanguage(Language.JAVA)
       // Allow to deserialize objects unknown types,
       // more flexible but less secure.
-      // .withSecureMode(false)
+      // .requireClassRegistration(false)
       .build();
     // Registering types can reduce class name serialization overhead, but not mandatory.
     // If secure mode enabled, all custom types must be registered.

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/start/usage.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/start/usage.md
@@ -21,7 +21,7 @@ public class Example {
     Fury fury = Fury.builder().withLanguage(Language.JAVA)
       // Allow to deserialize objects unknown types,
       // more flexible but less secure.
-      // .withSecureMode(false)
+      // .requireClassRegistration(false)
       .build();
     // Registering types can reduce class name serialization overhead, but not mandatory.
     // If secure mode enabled, all custom types must be registered.

--- a/src/pages/home/components/HomepageCodeDisplay.tsx
+++ b/src/pages/home/components/HomepageCodeDisplay.tsx
@@ -15,7 +15,7 @@ public class Example {
   static ThreadSafeFury fury = Fury.builder().withLanguage(Language.JAVA)
     // Allow to deserialize objects unknown types,
     // more flexible but less secure.
-    // .withSecureMode(false)
+    // .requireClassRegistration(false)
     .buildThreadSafeFury();
 
   static {


### PR DESCRIPTION
The `withSecureMode` API has already been replaced by `requireClassRegistration`. We should update it accordingly.