### PR TITLE
fix download link

### DIFF
--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -6,7 +6,7 @@ sidebar_position: 0
 
 The official Apache Fury releases are provided as source artifacts.
 
-For source download, please see Fury [download](https://github.com/apache/fury/releases) page.
+For source download, please see Fury [download](https://fury.apache.org/download) page.
 
 ## Java
 


### PR DESCRIPTION
We must use the Fury web site page and not the GitHub one.